### PR TITLE
Get 100 recent gists instead of default 30

### DIFF
--- a/lib/glist-view.coffee
+++ b/lib/glist-view.coffee
@@ -19,7 +19,7 @@ class GlistView extends SelectListView
     @setItems gistCache if gistCache
     @setLoading("Fetching All Gists...")
     @panel ?= atom.workspace.addModalPanel(item: this)
-    ghgist.list (error, gists) =>
+    ghgist.list 1, 100, (error, gists) =>
       indexedGists = _(gists).map (gist) ->
         gist.key = gist.description + " " + _.values(gist.files)
           .map (file)->


### PR DESCRIPTION
Hi guys,

Currently only 30 recent gists are fetched - I've increased it to 100 (maximum) per page.
PS. 1st page means the most recent gists
